### PR TITLE
Fix windows reference for platform

### DIFF
--- a/src/mascarpone.gleam
+++ b/src/mascarpone.gleam
@@ -159,10 +159,14 @@ fn get_bundled_bun_path() -> SnagResult(String) {
   let platform_str = get_bun_platform_string(platform)
   let arch_str = get_bun_arch_string(arch)
 
+  let bun_exe = case platform {
+      Windows -> "bun.exe"
+      _ -> "bun"
+  }
   let bun_path =
     filepath.join(
       root,
-      ".lustre/bin/bun-" <> platform_str <> "-" <> arch_str <> "/bun",
+      ".lustre/bin/bun-" <> platform_str <> "-" <> arch_str <> "/" <> bun_exe,
     )
 
   // Verify bundled bun exists

--- a/src/mascarpone.gleam
+++ b/src/mascarpone.gleam
@@ -1378,7 +1378,7 @@ type Architecture {
 
 fn detect_platform() -> SnagResult(Platform) {
   case operating_system.name() {
-    "windowsnt" -> Ok(Windows)
+    "windows_nt" -> Ok(Windows)
     "darwin" -> Ok(MacOS)
     _ -> Ok(Linux)
   }


### PR DESCRIPTION
I'm using windows(sorry) and when I tried this it gave me `error: Bun executable not found at ./.lustre/bin/bun-linux-x64/bun and not found in system PATH. Make sure lustre_dev_tools is properly installed or install bun globally.`

Tried it locally and should be windows_nt. Also need to use bun.exe instead of bun